### PR TITLE
Fix persistance of conditional element

### DIFF
--- a/src/bindings/if.js
+++ b/src/bindings/if.js
@@ -42,7 +42,7 @@ export const IfBinding = Object.seal({
     return this
   },
   unmount(scope, parentScope) {
-    this.template.unmount(scope, parentScope)
+    this.template.unmount(scope, parentScope, true)
 
     return this
   }

--- a/src/template.js
+++ b/src/template.js
@@ -114,7 +114,9 @@ export const TemplateChunk = Object.freeze({
 
       if (mustRemoveRoot && this.el.parentNode) {
         this.el.parentNode.removeChild(this.el)
-      } else if (mustRemoveRoot !== null) {
+      }
+
+      if (mustRemoveRoot !== null) {
         if (this.children) {
           clearChildren(this.children[0].parentNode, this.children)
         } else {

--- a/test/bindings/if.spec.js
+++ b/test/bindings/if.spec.js
@@ -68,9 +68,9 @@ describe('if bindings', () => {
     }]).mount(target, { isVisible: true })
 
     expect(target.querySelectorAll('strong')).to.have.length(1)
-    el.update({ text: 'goodbye', isVisible: false })
+    el.update({ isVisible: false })
     expect(target.querySelectorAll('strong')).to.have.length(0)
-    el.update({ text: 'goodbye', isVisible: true })
+    el.update({ isVisible: true })
     expect(target.querySelectorAll('strong')).to.have.length(1)
 
     el.unmount()

--- a/test/bindings/if.spec.js
+++ b/test/bindings/if.spec.js
@@ -23,9 +23,11 @@ describe('if bindings', () => {
     const target = document.createElement('div')
     const el = createDummyIfTemplate().mount(target, { text: 'hello', isVisible: true })
 
+    expect(target.querySelector('p')).to.be.ok
     expect(target.querySelector('b').textContent).to.be.equal('hello')
     el.update({ text: 'hello', isVisible: false })
 
+    expect(target.querySelector('p')).to.be.not.ok
     expect(target.querySelector('b')).to.be.not.ok
 
     el.unmount()
@@ -35,8 +37,9 @@ describe('if bindings', () => {
     const target = document.createElement('div')
     const el = createDummyIfTemplate().mount(target, { text: 'hello', isVisible: false })
 
-    expect(target.querySelector('b')).to.be.not.ok
+    expect(target.querySelector('p')).to.be.not.ok
     el.update({ text: 'hello', isVisible: true })
+    expect(target.querySelector('p')).to.be.ok
     expect(target.querySelector('b').textContent).to.be.equal('hello')
 
     el.unmount()
@@ -77,11 +80,11 @@ describe('if bindings', () => {
     const target = document.createElement('div')
     const el = createDummyIfTemplate().mount(target, { text: 'hello', isVisible: null })
 
-    expect(target.querySelector('b')).to.be.not.ok
+    expect(target.querySelector('p')).to.be.not.ok
 
     el.update({ text: 'goodbye', isVisible: [] })
 
-    expect(target.querySelector('b')).to.be.ok
+    expect(target.querySelector('p')).to.be.ok
 
     el.unmount()
   })


### PR DESCRIPTION
This should fix https://github.com/riot/riot/issues/2739
From what I've understood the tests of the if bindings are wrong:
https://github.com/riot/dom-bindings/blob/9697d1fb7429c3a0b494c0ee6b472b470a054434/test/bindings/if.spec.js#L3-L32
The if condition is on the `<p>` element, but the code checks for the removal of `<b>` which has just a simple binding with text.
I corrected the tests and fixed the implementation of `unmount` to make them pass.
I also compiled riot with these changes and the problem seems fixed, the change shouldn't mess up existing code (although I haven't found exhaustive tests to be sure about it)