### PR TITLE
Fix crashes when using <Template>

### DIFF
--- a/src/binding.js
+++ b/src/binding.js
@@ -27,8 +27,12 @@ export default function create(root, binding, templateTagOffset) {
   const { selector, type, redundantAttribute, expressions } = binding
   // find the node to apply the bindings
   const node = selector ? root.querySelector(selector) : root
+
+  if (!node) return null
+
   // remove eventually additional attributes created only to select this node
   if (redundantAttribute) node.removeAttribute(redundantAttribute)
+
   const bindingExpressions = expressions || []
   // init the binding
   return (bindings[type] || bindings[SIMPLE])(

--- a/src/template.js
+++ b/src/template.js
@@ -95,7 +95,7 @@ export const TemplateChunk = Object.freeze({
       this.el,
       binding,
       templateTagOffset
-    ))
+    )).filter(binding => binding)
     this.bindings.forEach(b => b.mount(scope, parentScope))
 
     // store the template meta properties

--- a/src/template.js
+++ b/src/template.js
@@ -64,11 +64,6 @@ export const TemplateChunk = Object.freeze({
     // so we check the parent node to set the query selector bindings
     const {parentNode} = children ? children[0] : el
     const isTemplateTag = isTemplate(el)
-    const templateTagOffset = isTemplateTag ? Math.max(
-      Array.from(parentNode.childNodes).indexOf(el),
-      0
-    ) : null
-    this.isTemplateTag = isTemplateTag
 
     // create the DOM if it wasn't created before
     this.createDOM(el)
@@ -78,11 +73,21 @@ export const TemplateChunk = Object.freeze({
     // create the new template dom fragment if it want already passed in via meta
     const fragment = meta.fragment || (this.dom ? this.dom.cloneNode(true) : null)
 
+    this.isTemplateTag = isTemplateTag
     // store root node
     // notice that for template tags the root note will be the parent tag
-    this.el = this.isTemplateTag ? parentNode : el
+    this.el = isTemplateTag ? parentNode : el
+
     // create the children array only for the <template> fragments
-    this.children = this.isTemplateTag && (children || fragment) ? children || Array.from(fragment.childNodes) : null
+    this.children = isTemplateTag && (children || fragment) ? children || Array.from(fragment.childNodes) : null
+
+    // find text expressions offset for <template> fragments
+    const templateSiblingNodes = isTemplateTag && Array.from(parentNode.childNodes)
+    const templateTagOffset = isTemplateTag && Math.max(
+      templateSiblingNodes.indexOf(el),
+      templateSiblingNodes.indexOf(meta.head) + 1,
+      0
+    )
 
     // inject the DOM into the el only if a fragment is available
     if (!avoidDOMInjection) {
@@ -104,6 +109,7 @@ export const TemplateChunk = Object.freeze({
 
     return this
   },
+
   /**
    * Update the template with fresh data
    * @param   {*} scope - template data
@@ -115,11 +121,12 @@ export const TemplateChunk = Object.freeze({
 
     return this
   },
+
   /**
    * Remove the template from the node where it was initially mounted
    * @param   {*} scope - template data
-   * @param   {*} parentScope - scope of the parent template tag
-   * @param   {boolean|null} mustRemoveRoot - if true remove the root element,
+   * @param   {*?} parentScope - scope of the parent template tag
+   * @param   {boolean|null?} mustRemoveRoot - if true remove the root element,
    * if false or undefined clean the root tag content, if null don't touch the DOM
    * @returns {TemplateChunk} self
    */
@@ -154,6 +161,7 @@ export const TemplateChunk = Object.freeze({
 
     return this
   },
+
   /**
    * Clone the template chunk
    * @returns {TemplateChunk} a clone of this object resetting the this.el property

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -172,6 +172,35 @@ describe('core specs', () => {
     el.unmount()
   })
 
+
+  it('Template fragments can be empty', () => {
+    const target = document.createElement('div')
+
+    const el = template(
+      '<header></header><template expr1="expr1"></template><footer></footer>',
+      [
+        {
+          type: bindingTypes.IF,
+          evaluate: (scope) => scope.isVisible,
+          redundantAttribute: 'expr1',
+          selector: '[expr1]',
+          template: template(
+            null,
+            []
+          )
+        }
+      ]
+    ).mount(target, {
+      isVisible: true
+    })
+
+    expect(target.querySelector('header')).to.be.ok
+    expect(target.querySelector('template')).to.be.not.ok
+    expect(target.querySelector('footer')).to.be.ok
+
+    el.unmount()
+  })
+
   it('Template fragments work also with text nodes', () => {
     const target = document.createElement('div')
 

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -172,6 +172,17 @@ describe('core specs', () => {
     el.unmount()
   })
 
+  // Not sure what this is the correct behavior
+  it('Template fragments without bindings must stay in the DOM', () => {
+    const target = document.createElement('div')
+
+    const el = template('<h1>Title</h1><template>Hello</template>', []).mount(target, {})
+
+    expect(target.querySelector('template')).to.be.ok
+    expect(target.querySelector('template').innerHTML).to.be.equal('Hello')
+
+    el.unmount()
+  })
 
   it('Template fragments can be empty', () => {
     const target = document.createElement('div')


### PR DESCRIPTION
I found stupid problem with empty TEMPLATE tags with conditions:
https://codesandbox.io/s/riotjs-5-bug-template-forked-3vg9m?file=/my-tag.riot

Maybe this is the wrong solution and the problem is elsewhere, but it works and all tests passed