### PR TITLE
Fix issue https://github.com/riot/riot/issues/2925

### DIFF
--- a/src/binding.js
+++ b/src/binding.js
@@ -31,6 +31,7 @@ export default function create(root, binding, templateTagOffset) {
   // remove eventually additional attributes created only to select this node
   if (redundantAttribute) node.removeAttribute(redundantAttribute)
   const bindingExpressions = expressions || []
+
   // init the binding
   return (bindings[type] || bindings[SIMPLE])(
     node,

--- a/src/bindings/each.js
+++ b/src/bindings/each.js
@@ -90,7 +90,7 @@ function patch(redundant, parentScope) {
 
         // notice that we pass null as last argument because
         // the root node and its children will be removed by domdiff
-        if (nodes.length === 0) {
+        if (!nodes.length) {
           // we have cleared all the children nodes and we can unmount this template
           redundant.pop()
           template.unmount(context, parentScope, null)
@@ -109,7 +109,7 @@ function patch(redundant, parentScope) {
  * @returns {boolean} true if this item should be skipped
  */
 function mustFilterItem(condition, context) {
-  return condition ? Boolean(condition(context)) === false : false
+  return condition ? !condition(context) : false
 }
 
 /**
@@ -123,14 +123,8 @@ function mustFilterItem(condition, context) {
  * @returns {Object} enhanced scope object
  */
 function extendScope(scope, {itemName, indexName, index, item}) {
-  const options = {
-    enumerable: true,
-    writable: true,
-    configurable: true
-  }
-
-  defineProperty(scope, itemName, item, options)
-  if (indexName) defineProperty(scope, indexName, index, options)
+  defineProperty(scope, itemName, item)
+  if (indexName) defineProperty(scope, indexName, index)
 
   return scope
 }
@@ -153,7 +147,7 @@ function markEdgeNodes(nodes) {
  * @param   {Array} items - expression collection value
  * @param   {*} scope - template scope
  * @param   {*} parentScope - scope of the parent template
- * @param   {EeachBinding} binding - each binding object instance
+ * @param   {EachBinding} binding - each binding object instance
  * @returns {Object} data
  * @returns {Map} data.newChildrenMap - a Map containing the new children template structure
  * @returns {Array} data.batches - array containing the template lifecycle functions to trigger

--- a/src/bindings/each.js
+++ b/src/bindings/each.js
@@ -1,6 +1,7 @@
 import {HEAD_SYMBOL, TAIL_SYMBOL} from '../constants'
 import {insertBefore, removeChild} from '@riotjs/util/dom'
 import createTemplateMeta from '../util/create-template-meta'
+import {defineProperty} from '@riotjs/util/objects'
 import getFragmentChildren from '../util/get-fragment-children'
 import {isTemplate} from '@riotjs/util/checks'
 import udomdiff from '../util/udomdiff'
@@ -114,6 +115,7 @@ function mustFilterItem(condition, context) {
 /**
  * Extend the scope of the looped template
  * @param   {Object} scope - current template scope
+ * @param   {Object} options - options
  * @param   {string} options.itemName - key to identify the looped item in the new context
  * @param   {string} options.indexName - key to identify the index of the looped item
  * @param   {number} options.index - current index
@@ -121,8 +123,15 @@ function mustFilterItem(condition, context) {
  * @returns {Object} enhanced scope object
  */
 function extendScope(scope, {itemName, indexName, index, item}) {
-  scope[itemName] = item
-  if (indexName) scope[indexName] = index
+  const options = {
+    enumerable: true,
+    writable: true,
+    configurable: true
+  }
+
+  defineProperty(scope, itemName, item, options)
+  if (indexName) defineProperty(scope, indexName, index, options)
+
   return scope
 }
 

--- a/src/expressions/attribute.js
+++ b/src/expressions/attribute.js
@@ -1,4 +1,4 @@
-import {isBoolean, isFunction, isNil, isObject} from '@riotjs/util/checks'
+import {isBoolean, isFunction, isObject} from '@riotjs/util/checks'
 import {memoize} from '@riotjs/util/misc'
 
 const ElementProto = typeof Element === 'undefined' ? {} : Element.prototype
@@ -47,7 +47,7 @@ function canRenderAttribute(value) {
  * @returns {boolean} boolean - true if the attribute can be removed}
  */
 function shouldRemoveAttribute(value) {
-  return isNil(value) || value === false || value === ''
+  return !value && value !== 0
 }
 
 /**
@@ -101,7 +101,5 @@ export default function attributeExpression(node, { name }, value, oldValue) {
  */
 function normalizeValue(name, value) {
   // be sure that expressions like selected={ true } will be always rendered as selected='selected'
-  if (value === true) return name
-
-  return value
+  return (value === true) ? name : value
 }

--- a/src/expressions/text.js
+++ b/src/expressions/text.js
@@ -4,7 +4,7 @@ import normalizeStringValue from '../util/normalize-string-value'
  * Get the the target text node to update or create one from of a comment node
  * @param   {HTMLElement} node - any html element containing childNodes
  * @param   {number} childNodeIndex - index of the text node in the childNodes list
- * @returns {HTMLTextNode} the text node to update
+ * @returns {Text} the text node to update
  */
 export const getTextNode = (node, childNodeIndex) => {
   const target = node.childNodes[childNodeIndex]

--- a/src/util/create-head-tail-placeholders.js
+++ b/src/util/create-head-tail-placeholders.js
@@ -3,7 +3,7 @@ import {HEAD_SYMBOL, TAIL_SYMBOL} from '../constants'
 
 /**
  * Create the <template> fragments text nodes
- * @return {Object} {{head: TextNode, tail: TextNode}}
+ * @return {Object} {{head: Text, tail: Text}}
  */
 export default function createHeadTailPlaceholders() {
   const head = document.createTextNode('')

--- a/test/bindings/each.spec.js
+++ b/test/bindings/each.spec.js
@@ -10,42 +10,44 @@ function compareNodesContents(target, selector, items) {
 }
 
 function createDummyListTemplate(options = {}) {
+  const itemName = options.itemName || 'val'
+
   return template('<ul><li expr0></li></ul>', [{
-    ...{
-      selector: '[expr0]',
-      type: bindingTypes.EACH,
-      itemName: 'val',
-      evaluate: scope => scope.items,
-      template: template('<!---->', [{
-        expressions: [
-          {
-            type: expressionTypes.TEXT,
-            childNodeIndex: 0,
-            evaluate: scope => scope.val
-          }
-        ]
-      }])
-    }, ...options
+    selector: '[expr0]',
+    type: bindingTypes.EACH,
+    itemName,
+    evaluate: scope => scope.items,
+    template: template('<!---->', [{
+      expressions: [
+        {
+          type: expressionTypes.TEXT,
+          childNodeIndex: 0,
+          evaluate: scope => scope[itemName]
+        }
+      ]
+    }]),
+    ...options
   }])
 }
 
 function createDummyListWithSiblingsTemplate(options = {}) {
+  const itemName = options.itemName || 'val'
+
   return template('<ul><li>first</li><li expr0></li><li>last</li></ul>', [{
-    ...{
-      selector: '[expr0]',
-      type: bindingTypes.EACH,
-      itemName: 'val',
-      evaluate: scope => scope.items,
-      template: template('<!---->', [{
-        expressions: [
-          {
-            type: expressionTypes.TEXT,
-            childNodeIndex: 0,
-            evaluate: scope => scope.val
-          }
-        ]
-      }])
-    }, ...options
+    selector: '[expr0]',
+    type: bindingTypes.EACH,
+    itemName,
+    evaluate: scope => scope.items,
+    template: template('<!---->', [{
+      expressions: [
+        {
+          type: expressionTypes.TEXT,
+          childNodeIndex: 0,
+          evaluate: scope => scope[itemName]
+        }
+      ]
+    }]),
+    ...options
   }])
 }
 
@@ -305,6 +307,23 @@ describe('each bindings', () => {
 
     expect(divs[0].textContent).to.be.equal('0')
     expect(divs[1].textContent).to.be.equal('1')
+
+    el.unmount()
+  })
+
+
+  it('Each bindings can use readonly field names from scope as itemName (issue https://github.com/riot/riot/issues/2925)', () => {
+    const items = ['q', 'w', 'e', 'r', 't', 'y']
+    const target = document.createElement('div')
+
+    const el = createDummyListTemplate({
+      itemName: 'root',
+      indexName: 'template'
+    }).mount(target, {items})
+
+    const content = target.textContent
+
+    expect(content).to.be.equal('qwerty')
 
     el.unmount()
   })

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -359,7 +359,7 @@ describe('core specs', () => {
     el.unmount()
   })
 
-  it('The content attribute doesn\'t break the rendering (https://github.com/riot/riot/issues/2913)', () => {
+  it('The content attribute doesn\'t break the rendering (issue https://github.com/riot/riot/issues/2913)', () => {
     const target = document.createElement('div')
 
     target.content = true

--- a/test/expressions/attribute.spec.js
+++ b/test/expressions/attribute.spec.js
@@ -46,17 +46,35 @@ describe('attribute specs', () => {
   })
 
   it('remove attribute if it\'s falsy', () => {
-    const target = document.createElement('div')
-    template('<p class="hello" expr0></p>', [{
-      selector: '[expr0]',
+    const createExpression = (attr, name, key) => ({
+      selector: `[${attr}]`,
       expressions: [
-        { type: expressionTypes.ATTRIBUTE, name: 'class', evaluate: scope => scope.attr }
+        { type: expressionTypes.ATTRIBUTE, name, evaluate: scope => scope[key] }
       ]
-    }]).mount(target, { attr: '' })
+    })
+
+    const target = document.createElement('div')
+    template('<p class="hello" expr0 expr1 expr2 expr3 expr4></p>', [
+      createExpression('expr0', 'as-string', 'asString'),
+      createExpression('expr1', 'as-false', 'asFalse'),
+      createExpression('expr2', 'as-nan', 'asNaN'),
+      createExpression('expr3', 'as-null', 'asNull'),
+      createExpression('expr4', 'as-void', 'asVoid')
+    ]).mount(target, {
+      asString: '',
+      asFalse: false,
+      asNaN: NaN,
+      asNull: null,
+      asVoid: undefined
+    })
 
     const p = target.querySelector('p')
 
-    expect(p.hasAttribute('class')).to.be.not.ok
+    expect(p.hasAttribute('as-string')).to.be.not.ok
+    expect(p.hasAttribute('as-false')).to.be.not.ok
+    expect(p.hasAttribute('as-nan')).to.be.not.ok
+    expect(p.hasAttribute('as-null')).to.be.not.ok
+    expect(p.hasAttribute('as-void')).to.be.not.ok
   })
 
   it('do not remove remove number attributes', () => {
@@ -71,6 +89,20 @@ describe('attribute specs', () => {
     const p = target.querySelector('p')
 
     expect(p.hasAttribute('class')).to.be.ok
+  })
+
+  it('Expressions will replace own attributes', () => {
+    const target = document.createElement('div')
+    template('<p test="bar" expr0 test="baz"></p>', [{
+      selector: '[expr0]',
+      expressions: [
+        { type: expressionTypes.ATTRIBUTE, name: 'test', evaluate: scope => scope.attr }
+      ]
+    }]).mount(target, { attr: 'foo' })
+
+    const p = target.querySelector('p')
+
+    expect(p.getAttribute('test')).to.be.equal('foo')
   })
 
   it('toggle attribute', () => {


### PR DESCRIPTION
This merge request fixes a bug https://github.com/riot/riot/issues/2925.
The only thing is that the test that I wrote was successfully executed before the fix, but it breaks in a real environment and this patch is guaranteed to work.

It also does not solve the problem with the inability to use the `css`, `slots`, `template` fields in your RiotComponentExport, but I'm not sure if the framework should worry about such situations. On the other hand, these restrictions are not documented in any way and are not obvious to the user of the framework. It would be better to encapsulate these fields. I also find it strange this code `this[TEMPLATE_KEY_SYMBOL] = this.template.createDOM(element).clone ()` and I don't really understand why it is necessary to store `this [TEMPLATE_KEY_SYMBOL]` and `this.template` at the same time and what is the fundamental difference between them.